### PR TITLE
Iss22 dont flag as const

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-known-imports",
-  "version": "0.0.15-dev.1",
+  "version": "0.0.15-dev.2",
   "description": "ESLint plugin to generate missing/remove unused project-specific known imports",
   "main": "lib/index.js",
   "repository": "https://github.com/helixbass/eslint-plugin-known-imports",

--- a/src/rules/no-undef-types.coffee
+++ b/src/rules/no-undef-types.coffee
@@ -195,6 +195,7 @@ module.exports =
 
     ImportDeclaration: (node) -> allImports.push node
     Identifier: (node) ->
+      return if node.name is 'const'
       if node.parent?.type is 'TSTypeReference' and node is node.parent.typeName
         allIdentifiersWhichAreTypeReferences[node.name] = node
       else


### PR DESCRIPTION
Fixes #22 

In this PR:
- Fix bug where `no-undef-types` was flagging `as const`