### PR TITLE
Deal with multiple possible imports

### DIFF
--- a/src/tests/fixtures/ambiguous1.coffee
+++ b/src/tests/fixtures/ambiguous1.coffee
@@ -1,0 +1,1 @@
+export ambiguous = ->

--- a/src/tests/fixtures/nested/ambiguous2.coffee
+++ b/src/tests/fixtures/nested/ambiguous2.coffee
@@ -1,0 +1,1 @@
+export ambiguous = ->

--- a/src/tests/rules/no-undef.coffee
+++ b/src/tests/rules/no-undef.coffee
@@ -476,7 +476,7 @@ ruleTester.run 'no-undef', rule,
     settings:
       'known-imports/relative-paths': yes
     output: '''
-      import Empty from './lib/tests/fixtures/Empty'
+      import Empty from './tests/fixtures/Empty'
 
       Empty()
     '''
@@ -484,20 +484,35 @@ ruleTester.run 'no-undef', rule,
       message: "'Empty' is not defined."
       type: 'Identifier'
     ]
-    filename: 'foo.js'
+    filename: 'lib/foo.js'
   ,
-    # should-autoimport-ambiguous-imports setting
+    # prefer "nearest" import in terms of parent directories
     code: '''
       ambiguous()
     '''
-    settings:
-      'known-imports/should-autoimport-ambiguous-imports': false
     output: '''
+      import {ambiguous} from 'fixtures/nested/ambiguous2'
+
       ambiguous()
     '''
     errors: [
       message: "'ambiguous' is not defined."
       type: 'Identifier'
     ]
-    filename: 'foo.js'
+    filename: 'lib/tests/fixtures/nested/foo.js'
+  ,
+    # prefer "nearest" import in terms of nested directories
+    code: '''
+      ambiguous()
+    '''
+    output: '''
+      import {ambiguous} from 'fixtures/ambiguous1'
+
+      ambiguous()
+    '''
+    errors: [
+      message: "'ambiguous' is not defined."
+      type: 'Identifier'
+    ]
+    filename: 'lib/foo.js'
   ]

--- a/src/tests/rules/no-undef.coffee
+++ b/src/tests/rules/no-undef.coffee
@@ -485,4 +485,19 @@ ruleTester.run 'no-undef', rule,
       type: 'Identifier'
     ]
     filename: 'foo.js'
+  ,
+    # should-autoimport-ambiguous-imports setting
+    code: '''
+      ambiguous()
+    '''
+    settings:
+      'known-imports/should-autoimport-ambiguous-imports': false
+    output: '''
+      ambiguous()
+    '''
+    errors: [
+      message: "'ambiguous' is not defined."
+      type: 'Identifier'
+    ]
+    filename: 'foo.js'
   ]

--- a/src/utils/index.coffee
+++ b/src/utils/index.coffee
@@ -1,7 +1,12 @@
 fs = require 'fs'
 pathModule = require 'path'
-{last, isString, mergeWith, startsWith} = require 'lodash'
-{filter: ffilter, mapValues: fmapValues} = require 'lodash/fp'
+{last, isString, mergeWith, startsWith, first} = require 'lodash'
+{
+  filter: ffilter
+  mapValues: fmapValues
+  sortBy
+  takeWhile
+} = require 'lodash/fp'
 {default: ExportMap} = require 'eslint-plugin-import/lib/ExportMap'
 pkgDir = require 'pkg-dir'
 
@@ -225,24 +230,65 @@ findKnownImportInDirectory = ({
   }
 
   foundExact = directoryCache.get(name) ? []
-  foundCaseInsensitive = if (
-    settings['known-imports/case-insensitive-whitelist-filename']
-  )
-    directoryCache.get(name.toLowerCase()) ? []
-  else
-    []
+  foundCaseInsensitive = (
+    if settings['known-imports/case-insensitive-whitelist-filename']
+      directoryCache.get(name.toLowerCase()) ? []
+    else
+      []
+  ).filter ({type}) -> type is 'filename'
+  hasAmbiguousMatches =
+    foundExact.length > 1 or
+    (not foundExact.length and foundCaseInsensitive.length > 1)
   return null if (
     settings['known-imports/should-autoimport-ambiguous-imports'] is no and
-    (foundExact.length > 1 or
-      (not foundExact.length and foundCaseInsensitive.length > 1))
+    hasAmbiguousMatches
   )
-  return null unless found = foundExact[0] ? foundCaseInsensitive[0]
-  {prefixRelativePath, fullPath, type} = found
-  return null if type isnt 'filename' and not foundExact.length
-
   filename = context.getFilename()
+  getRelativePath = ({fullPath}) ->
+    pathModule.relative pathModule.dirname(filename), fullPath
+  getDotsPrefixLength = (match) ->
+    [
+      _ # eslint-disable-line coffee/no-unused-vars
+      dotsPrefix
+    ] = ///
+      ^
+      (
+        (?:
+          \.\./
+        ) *
+      )
+    ///.exec getRelativePath match
+    dotsPrefix.length
+  found = if hasAmbiguousMatches
+    ambiguousMatches = if foundExact.length
+      foundExact
+    else
+      foundCaseInsensitive
+    closestFirst = sortBy(getDotsPrefixLength) ambiguousMatches
+    shortestDotsPrefixLength = getDotsPrefixLength closestFirst[0]
+    haveSameSharedParentDirectory =
+      takeWhile((match) ->
+        getDotsPrefixLength(match) is shortestDotsPrefixLength
+      ) closestFirst
+    first(
+      sortBy((match) ->
+        getRelativePath(match).replace(
+          ///
+          /
+          [^/] +
+          $
+        ///
+          ''
+        ).length
+      ) haveSameSharedParentDirectory
+    )
+  else
+    [...foundExact, ...foundCaseInsensitive][0]
+  return null unless found
+  {prefixRelativePath, type} = found
+
   importPath = if settings['known-imports/relative-paths']
-    relativePath = pathModule.relative pathModule.dirname(filename), fullPath
+    relativePath = getRelativePath found
     extension = pathModule.extname relativePath
     ensureLeadingDot(
       if extension in extensions


### PR DESCRIPTION
Fixes #33 

In this PR:
- support new `should-autoimport-ambiguous-imports` setting for indicating that you don't want to autoimport if there are multiple possible matching imports
- otherwise, when there are multiple possible matching imports, choose the "nearest" one to the importing file

Not in this PR:
- describing the setting/behavior in the README