### PR TITLE
Allow ignoring certain whitelisted files

### DIFF
--- a/known-imports.yaml
+++ b/known-imports.yaml
@@ -21,5 +21,7 @@ whitelist:
     allowed: [filename, named]
     prefix: fixtures
     recursive: true
+    ignore:
+      - ignored1.js
 blacklist:
   - blacklisted

--- a/known-imports.yaml
+++ b/known-imports.yaml
@@ -23,5 +23,7 @@ whitelist:
     recursive: true
     ignore:
       - ignored1.js
+      - ignoredNested/
+      - /ignoredTopLevel/
 blacklist:
   - blacklisted

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-react": "^7.10.0",
+    "glob": "^7.1.6",
     "js-yaml": "^3.12.0",
     "lodash": "^4.17.10",
     "pkg-dir": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   "dependencies": {
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-react": "^7.10.0",
-    "glob": "^7.1.6",
     "js-yaml": "^3.12.0",
     "lodash": "^4.17.10",
+    "picomatch": "^2.2.2",
     "pkg-dir": "^4.2.0"
   }
 }

--- a/src/tests/fixtures/ignored1.coffee
+++ b/src/tests/fixtures/ignored1.coffee
@@ -1,0 +1,1 @@
+export default 3

--- a/src/tests/fixtures/ignored1.coffee
+++ b/src/tests/fixtures/ignored1.coffee
@@ -1,1 +1,3 @@
 export default 3
+
+export ignored1Named = -> 1

--- a/src/tests/fixtures/ignoredTopLevel/ignTopLevel.coffee
+++ b/src/tests/fixtures/ignoredTopLevel/ignTopLevel.coffee
@@ -1,0 +1,1 @@
+export default 3

--- a/src/tests/fixtures/nested/ignoredNested/ign.coffee
+++ b/src/tests/fixtures/nested/ignoredNested/ign.coffee
@@ -1,0 +1,3 @@
+export default 3
+
+export ignoredNested = -> 1

--- a/src/tests/fixtures/nested/ignoredTopLevel/ignTopLevelNested.coffee
+++ b/src/tests/fixtures/nested/ignoredTopLevel/ignTopLevelNested.coffee
@@ -1,0 +1,1 @@
+export default 3

--- a/src/tests/rules/no-undef.coffee
+++ b/src/tests/rules/no-undef.coffee
@@ -515,4 +515,17 @@ ruleTester.run 'no-undef', rule,
       type: 'Identifier'
     ]
     filename: 'lib/foo.js'
+  ,
+    # ignore option: filename import + filename glob
+    code: '''
+      ignored1()
+    '''
+    output: '''
+      ignored1()
+    '''
+    errors: [
+      message: "'ignored1' is not defined."
+      type: 'Identifier'
+    ]
+    filename: 'lib/foo.js'
   ]

--- a/src/tests/rules/no-undef.coffee
+++ b/src/tests/rules/no-undef.coffee
@@ -528,4 +528,58 @@ ruleTester.run 'no-undef', rule,
       type: 'Identifier'
     ]
     filename: 'lib/foo.js'
+  ,
+    # ignore option: named import + filename glob
+    code: '''
+      ignored1Named()
+    '''
+    output: '''
+      ignored1Named()
+    '''
+    errors: [
+      message: "'ignored1Named' is not defined."
+      type: 'Identifier'
+    ]
+    filename: 'lib/foo.js'
+  ,
+    # ignore option: filename import + directory glob
+    code: '''
+      ign()
+    '''
+    output: '''
+      ign()
+    '''
+    errors: [
+      message: "'ign' is not defined."
+      type: 'Identifier'
+    ]
+    filename: 'lib/foo.js'
+  ,
+    # ignore option: filename import + leading-slash directory glob + nested import
+    code: '''
+      ignTopLevelNested()
+    '''
+    output: '''
+      import ignTopLevelNested from 'fixtures/nested/ignoredTopLevel/ignTopLevelNested'
+
+      ignTopLevelNested()
+    '''
+    errors: [
+      message: "'ignTopLevelNested' is not defined."
+      type: 'Identifier'
+    ]
+    filename: 'lib/foo.js'
+  ,
+    # ignore option: filename import + leading-slash directory glob + non-nested import
+    code: '''
+      ignTopLevel()
+    '''
+    output: '''
+      ignTopLevel()
+    '''
+    errors: [
+      message: "'ignTopLevel' is not defined."
+      type: 'Identifier'
+    ]
+    filename: 'lib/foo.js'
   ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2039,6 +2039,11 @@ path-type@^2.0.0:
   dependencies:
     pify "^2.0.0"
 
+picomatch@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
+  integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"


### PR DESCRIPTION
Fixes #35 

In this PR:
- support ignoring certain whitelisted files via an `ignore` option under `whitelist`'ed directories