### PR TITLE
Newest typescript-eslint-compatible no-unused-vars

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -3,6 +3,7 @@ plugins:
   - coffee
 extends:
   - eslint:recommended
+  - plugin:coffee/disable-incompatible
   - plugin:coffee/all
   - plugin:coffee/prettier-run-as-rule
 rules:
@@ -40,6 +41,9 @@ rules:
   default-case: off
   coffee/id-length: off
   coffee/complexity: off
+  coffee/no-underscore-dangle: off
+  coffee/valid-jsdoc: off
+  coffee/spaced-comment: off
 env:
   node: true
   es6: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-known-imports",
-  "version": "0.0.15-beta.2",
+  "version": "0.1.0-dev.1",
   "description": "ESLint plugin to generate missing/remove unused project-specific known imports",
   "main": "lib/index.js",
   "repository": "https://github.com/helixbass/eslint-plugin-known-imports",

--- a/package.json
+++ b/package.json
@@ -27,13 +27,16 @@
     "coffeescript": "^2.5.1",
     "eslint": "^6.0.0",
     "eslint-config-prettier": "^2.9.0",
-    "eslint-plugin-coffee": "^0.1.12",
+    "eslint-plugin-coffee": "github:helixbass/eslint-plugin-coffee#eslint-plugin-coffee-v0.1.15-dev.1-gitpkg",
     "eslint-plugin-prettier": "^2.6.2",
     "mocha": "^5.2.0",
     "prettier": "github:helixbass/prettier#b8818ebd",
     "prettier-plugin-coffeescript": "^0.1.4"
   },
   "dependencies": {
+    "@typescript-eslint/eslint-plugin": "^4.15.1",
+    "@typescript-eslint/experimental-utils": "^4.15.1",
+    "@typescript-eslint/scope-manager": "^4.15.1",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-react": "^7.10.0",
     "js-yaml": "^3.12.0",

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -2,7 +2,7 @@ module.exports =
   rules:
     'no-undef': require './rules/no-undef'
     'jsx-no-undef': require './rules/jsx-no-undef'
-    'no-unused-vars': require './rules/no-unused-vars'
+    'no-unused-vars': require './rules/no-unused-vars-typescript'
     'react-in-jsx-scope': require './rules/react-in-jsx-scope'
     'no-undef-types': require './rules/no-undef-types'
   configs:

--- a/src/rules/no-unused-vars-typescript.coffee
+++ b/src/rules/no-unused-vars-typescript.coffee
@@ -1,0 +1,462 @@
+{AST_NODE_TYPES, TSESLint} = require '@typescript-eslint/experimental-utils'
+{PatternVisitor} = require '@typescript-eslint/scope-manager'
+util = require '@typescript-eslint/eslint-plugin/dist/util'
+{getRemoveImportFix} = require '../utils'
+
+module.exports = util.createRule(
+  name: 'no-unused-vars'
+  meta:
+    type: 'problem'
+    docs:
+      description: 'Disallow unused variables'
+      category: 'Variables'
+      recommended: 'warn'
+      extendsBaseRule: yes
+    schema: [
+      oneOf: [
+        enum: ['all', 'local']
+      ,
+        type: 'object'
+        properties:
+          vars:
+            enum: ['all', 'local']
+          varsIgnorePattern:
+            type: 'string'
+          args:
+            enum: ['all', 'after-used', 'none']
+          ignoreRestSiblings:
+            type: 'boolean'
+          argsIgnorePattern:
+            type: 'string'
+          caughtErrors:
+            enum: ['all', 'none']
+          caughtErrorsIgnorePattern:
+            type: 'string'
+          onlyRemoveKnownImports:
+            type: 'boolean'
+        additionalProperties: no
+      ]
+    ]
+    messages:
+      unusedVar: "'{{varName}}' is {{action}} but never used{{additional}}."
+    fixable: 'code'
+  defaultOptions: [{}]
+  create: (context) ->
+    filename = context.getFilename()
+    sourceCode = context.getSourceCode()
+    MODULE_DECL_CACHE = new Map()
+
+    checkModuleDeclForExportEquals = (node) ->
+      cached = MODULE_DECL_CACHE.get node
+      return cached if cached?
+
+      for statement from node.body?.body ? []
+        if statement.type is AST_NODE_TYPES.TSExportAssignment
+          MODULE_DECL_CACHE.set node, yes
+          return yes
+
+      MODULE_DECL_CACHE.set node, no
+      no
+
+    markDeclarationChildAsUsed = (node) ->
+      identifiers = []
+      switch node.type
+        when AST_NODE_TYPES.TSInterfaceDeclaration, AST_NODE_TYPES.TSTypeAliasDeclaration, AST_NODE_TYPES.ClassDeclaration, AST_NODE_TYPES.FunctionDeclaration, AST_NODE_TYPES.TSDeclareFunction, AST_NODE_TYPES.TSEnumDeclaration, AST_NODE_TYPES.TSModuleDeclaration
+          if node.id?.type is AST_NODE_TYPES.Identifier
+            identifiers.push node.id
+
+        when AST_NODE_TYPES.VariableDeclaration
+          for declaration from node.declarations
+            visitPattern declaration, (pattern) ->
+              identifiers.push pattern
+              undefined
+
+      scope = context.getScope()
+      shouldUseUpperScope = [
+        AST_NODE_TYPES.TSModuleDeclaration
+        AST_NODE_TYPES.TSDeclareFunction
+      ].includes node.type
+
+      unless scope.variableScope is scope
+        scope = scope.variableScope
+      else if shouldUseUpperScope and scope.upper
+        scope = scope.upper
+
+      for id from identifiers
+        superVar = scope.set.get id.name
+        if superVar
+          superVar.eslintUsed = yes
+
+    visitPattern = (node, cb) ->
+      visitor = new PatternVisitor {}, node, cb
+      visitor.visit node
+
+    options = do ->
+      _options =
+        vars: 'all'
+        args: 'after-used'
+        ignoreRestSiblings: no
+        caughtErrors: 'none'
+        onlyRemoveKnownImports: no
+
+      firstOption = context.options[0]
+
+      if firstOption
+        if typeof firstOption is 'string'
+          _options.vars = firstOption
+        else
+          _options.vars = firstOption.vars ? _options.vars
+          _options.args = firstOption.args ? _options.args
+          _options.ignoreRestSiblings =
+            firstOption.ignoreRestSiblings ? _options.ignoreRestSiblings
+          _options.caughtErrors =
+            firstOption.caughtErrors ? _options.caughtErrors
+          _options.onlyRemoveKnownImports =
+            firstOption.onlyRemoveKnownImports ? _options.onlyRemoveKnownImports
+
+          if firstOption.varsIgnorePattern
+            _options.varsIgnorePattern = new RegExp(
+              firstOption.varsIgnorePattern
+              'u'
+            )
+
+          if firstOption.argsIgnorePattern
+            _options.argsIgnorePattern = new RegExp(
+              firstOption.argsIgnorePattern
+              'u'
+            )
+
+          if firstOption.caughtErrorsIgnorePattern
+            _options.caughtErrorsIgnorePattern = new RegExp(
+              firstOption.caughtErrorsIgnorePattern
+              'u'
+            )
+      _options
+
+    collectUnusedVariables = ->
+      ###*
+      # Determines if a variable has a sibling rest property
+      # @param variable eslint-scope variable object.
+      # @returns True if the variable is exported, false if not.
+      ###
+      hasRestSpreadSibling = (variable) ->
+        return variable.defs.some((def) ->
+          propertyNode = def.name.parent
+          patternNode = propertyNode.parent
+
+          propertyNode.type is AST_NODE_TYPES.Property and
+            patternNode.type is AST_NODE_TYPES.ObjectPattern and
+            patternNode.properties[patternNode.properties.length - 1].type is
+              AST_NODE_TYPES.RestElement
+        ) if options.ignoreRestSiblings
+
+        no
+
+      ###*
+      # Checks whether the given variable is after the last used parameter.
+      # @param variable The variable to check.
+      # @returns `true` if the variable is defined after the last used parameter.
+      ###
+      isAfterLastUsedArg = (variable) ->
+        def = variable.defs[0]
+        params = context.getDeclaredVariables def.node
+        posteriorParams = params.slice params.indexOf(variable) + 1
+
+        # If any used parameters occur after this parameter, do not report.
+        not posteriorParams.some (v) ->
+          v.references.length > 0 or v.eslintUsed
+
+      unusedVariablesOriginal = util.collectUnusedVariables context
+      unusedVariablesReturn = []
+      for variable from unusedVariablesOriginal
+        # explicit global variables don't have definitions.
+        if variable.defs.length is 0
+          unusedVariablesReturn.push variable
+          continue
+        def = variable.defs[0]
+
+        # skip variables in the global scope if configured to
+        continue if (
+          variable.scope.type is TSESLint.Scope.ScopeType.global and
+          options.vars is 'local'
+        )
+
+        # skip catch variables
+        if def.type is TSESLint.Scope.DefinitionType.CatchClause
+          continue if options.caughtErrors is 'none'
+          # skip ignored parameters
+          continue if (
+            'name' of def.name and
+            options.caughtErrorsIgnorePattern?.test def.name.name
+          )
+
+        if def.type is TSESLint.Scope.DefinitionType.Parameter
+          # if "args" option is "none", skip any parameter
+          continue if options.args is 'none'
+          # skip ignored parameters
+          continue if (
+            'name' of def.name and options.argsIgnorePattern?.test def.name.name
+          )
+          # if "args" option is "after-used", skip used variables
+          continue if (
+            options.args is 'after-used' and
+            util.isFunction(def.name.parent) and
+            not isAfterLastUsedArg variable
+          )
+        else
+          # skip ignored variables
+          continue if (
+            'name' of def.name and options.varsIgnorePattern?.test def.name.name
+          )
+
+        continue if hasRestSpreadSibling variable
+
+        # in case another rule has run and used the collectUnusedVariables,
+        # we want to ensure our selectors that marked variables as used are respected
+        continue if variable.eslintUsed
+
+        unusedVariablesReturn.push variable
+
+      unusedVariablesReturn
+
+    ambientDeclarationSelector = (parent, childDeclare) ->
+      [
+        # Types are ambiently exported
+        "#{parent} > :matches(#{[
+          AST_NODE_TYPES.TSInterfaceDeclaration
+          AST_NODE_TYPES.TSTypeAliasDeclaration
+        ].join ', '})"
+        # Value things are ambiently exported if they are "declare"d
+        "#{parent} > :matches(#{[
+          AST_NODE_TYPES.ClassDeclaration
+          AST_NODE_TYPES.TSDeclareFunction
+          AST_NODE_TYPES.TSEnumDeclaration
+          AST_NODE_TYPES.TSModuleDeclaration
+          AST_NODE_TYPES.VariableDeclaration
+        ].join ', '})#{if childDeclare then '[declare = true]' else ''}"
+      ].join ', '
+    return (
+      # declaration file handling
+
+
+        [ambientDeclarationSelector(AST_NODE_TYPES.Program, yes)]: (node) ->
+          return unless util.isDefinitionFile filename
+          markDeclarationChildAsUsed node
+          undefined
+
+        # children of a namespace that is a child of a declared namespace are auto-exported
+        [ambientDeclarationSelector(
+          'TSModuleDeclaration[declare = true] > TSModuleBlock TSModuleDeclaration > TSModuleBlock'
+          no
+        )]: (node) ->
+          markDeclarationChildAsUsed node
+          undefined
+
+        # declared namespace handling
+        [ambientDeclarationSelector(
+          'TSModuleDeclaration[declare = true] > TSModuleBlock'
+          no
+        )]: (node) ->
+          # declared ambient modules with an `export =` statement will only export that one thing
+          # all other statements are not automatically exported in this case
+          moduleDecl = util.nullThrows(
+            node.parent?.parent
+            util.NullThrowsReasons.MissingParent
+          )
+
+          return if (
+            moduleDecl.id.type is AST_NODE_TYPES.Literal and
+            checkModuleDeclForExportEquals moduleDecl
+          )
+
+          markDeclarationChildAsUsed node
+          undefined
+
+        # collect
+        'Program:exit': (programNode) ->
+          getDefinedMessageData = (unusedVar) ->
+            defType = unusedVar?.defs[0]?.type
+            if (
+              defType is TSESLint.Scope.DefinitionType.CatchClause and
+              options.caughtErrorsIgnorePattern
+            )
+              type = 'args'
+              pattern = options.caughtErrorsIgnorePattern.toString()
+            else if (
+              defType is TSESLint.Scope.DefinitionType.Parameter and
+              options.argsIgnorePattern
+            )
+              type = 'args'
+              pattern = options.argsIgnorePattern.toString()
+            else if (
+              defType isnt TSESLint.Scope.DefinitionType.Parameter and
+              options.varsIgnorePattern
+            )
+              type = 'vars'
+              pattern = options.varsIgnorePattern.toString()
+
+            additional = if type
+              ". Allowed unused #{type} must match #{pattern}"
+            else
+              ''
+
+            {
+              varName: unusedVar.name
+              action: 'defined'
+              additional
+            }
+
+          ###*
+          # Generate the warning message about the variable being
+          # assigned and unused, including the ignore pattern if configured.
+          # @param unusedVar eslint-scope variable object.
+          # @returns The message data to be used with this unused variable.
+          ###
+          getAssignedMessageData = (unusedVar) ->
+            additional = if options.varsIgnorePattern
+              ". Allowed unused vars must match #{options.varsIgnorePattern.toString()}"
+            else
+              ''
+
+            {
+              varName: unusedVar.name
+              action: 'assigned a value'
+              additional
+            }
+
+          unusedVars = collectUnusedVariables()
+
+          for unusedVar in unusedVars
+            # Report the first declaration.
+            if unusedVar.defs.length > 0
+              context.report
+                node: if unusedVar.references.length
+                  unusedVar.references[unusedVar.references.length - 1]
+                    .identifier
+                else
+                  unusedVar.identifiers[0]
+                messageId: 'unusedVar'
+                data: if (
+                  unusedVar.references.some((ref) ->
+                    ref.isWrite()
+                  )
+                )
+                  getAssignedMessageData unusedVar
+                else
+                  getDefinedMessageData unusedVar
+                fix: getRemoveImportFix {
+                  unusedVar
+                  context
+                  onlyRemoveKnownImports: options.onlyRemoveKnownImports
+                }
+
+              # If there are no regular declaration, report the first `/*globals*/` comment directive.
+            else if (
+              'eslintExplicitGlobalComments' of unusedVar and
+              unusedVar.eslintExplicitGlobalComments
+            )
+              directiveComment = unusedVar.eslintExplicitGlobalComments[0]
+
+              context.report
+                node: programNode
+                loc: util.getNameLocationInGlobalDirectiveComment(
+                  sourceCode
+                  directiveComment
+                  unusedVar.name
+                )
+                messageId: 'unusedVar'
+                data: getDefinedMessageData unusedVar
+          undefined
+    )
+)
+
+###
+
+Edge cases that aren't currently handled due to laziness and them being super edgy edge cases
+
+
+--- function params referenced in typeof type refs in the function declaration ---
+--- NOTE - TS gets these cases wrong
+
+function _foo(
+  arg: number // arg should be unused
+): typeof arg {
+  return 1 as any;
+}
+
+function _bar(
+  arg: number, // arg should be unused
+  _arg2: typeof arg,
+) {}
+
+
+--- function names referenced in typeof type refs in the function declaration ---
+--- NOTE - TS gets these cases right
+
+function foo( // foo should be unused
+): typeof foo {
+    return 1 as any;
+}
+
+function bar( // bar should be unused
+  _arg: typeof bar
+) {}
+
+
+--- if an interface is merged into a namespace  ---
+--- NOTE - TS gets these cases wrong
+
+namespace Test {
+    interface Foo { // Foo should be unused here
+        a: string;
+    }
+    export namespace Foo {
+       export type T = 'b';
+    }
+}
+type T = Test.Foo; // Error: Namespace 'Test' has no exported member 'Foo'.
+
+
+namespace Test {
+    export interface Foo {
+        a: string;
+    }
+    namespace Foo { // Foo should be unused here
+       export type T = 'b';
+    }
+}
+type T = Test.Foo.T; // Error: Namespace 'Test' has no exported member 'Foo'.
+###
+
+###
+
+We currently extend base `no-unused-vars` implementation because it's easier and lighter-weight.
+
+Because of this, there are a few false-negatives which won't get caught.
+We could fix these if we fork the base rule; but that's a lot of code (~650 lines) to add in.
+I didn't want to do that just yet without some real-world issues, considering these are pretty rare edge-cases.
+
+These cases are mishandled because the base rule assumes that each variable has one def, but type-value shadowing
+creates a variable with two defs
+
+--- type-only or value-only references to type/value shadowed variables ---
+--- NOTE - TS gets these cases wrong
+
+type T = 1;
+const T = 2; // this T should be unused
+
+type U = T; // this U should be unused
+const U = 3;
+
+const _V = U;
+
+
+--- partially exported type/value shadowed variables ---
+--- NOTE - TS gets these cases wrong
+
+export interface Foo {}
+const Foo = 1; // this Foo should be unused
+
+interface Bar {} // this Bar should be unused
+export const Bar = 1;
+###

--- a/src/tests/rules/no-unused-vars.coffee
+++ b/src/tests/rules/no-unused-vars.coffee
@@ -10,7 +10,7 @@
 #------------------------------------------------------------------------------
 
 eslint = require 'eslint'
-rule = require '../../rules/no-unused-vars'
+rule = require '../../rules/no-unused-vars-typescript'
 {RuleTester} = eslint
 
 #------------------------------------------------------------------------------
@@ -36,214 +36,214 @@ definedError = (varName, type) ->
 ruleTester.run 'no-unused-vars', rule,
   valid: [code: 'export var foo = 123;']
   invalid: [
-    code: """
+    code: '''
       import x from "y";
       export const a = 1;
-    """
-    output: """
+    '''
+    output: '''
       export const a = 1;
-    """
+    '''
     errors: [definedError 'x']
     options: [onlyRemoveKnownImports: no]
   ,
-    code: """
+    code: '''
       import {x} from "y";
       export const a = 1;
-    """
-    output: """
+    '''
+    output: '''
       export const a = 1;
-    """
+    '''
     errors: [definedError 'x']
     options: [onlyRemoveKnownImports: no]
   ,
-    code: """
+    code: '''
       import {x} from "y";
 
       // leading comment
       export const a = 1;
-    """
-    output: """
+    '''
+    output: '''
       // leading comment
       export const a = 1;
-    """
+    '''
     errors: [definedError 'x']
     options: [onlyRemoveKnownImports: no]
   ,
-    code: """
+    code: '''
       import {x, y} from "y";
       export {y};
-    """
-    output: """
+    '''
+    output: '''
       import {y} from "y";
       export {y};
-    """
+    '''
     errors: [definedError 'x']
     options: [onlyRemoveKnownImports: no]
   ,
-    code: """
+    code: '''
       import {w, x, y} from "y";
       export {w, y};
-    """
-    output: """
+    '''
+    output: '''
       import {w, y} from "y";
       export {w, y};
-    """
+    '''
     errors: [definedError 'x']
     options: [onlyRemoveKnownImports: no]
   ,
-    code: """
+    code: '''
       import {w, x} from "y";
       export {w};
-    """
-    output: """
+    '''
+    output: '''
       import {w} from \"y\";
       export {w};
-    """
+    '''
     errors: [definedError 'x']
     options: [onlyRemoveKnownImports: no]
   ,
-    code: """
+    code: '''
       import x, {w} from "y";
       export {w};
-    """
-    output: """
+    '''
+    output: '''
       import {w} from "y";
       export {w};
-    """
+    '''
     errors: [definedError 'x']
     options: [onlyRemoveKnownImports: no]
   ,
-    code: """
+    code: '''
       import w, {x} from "y";
       export {w};
-    """
-    output: """
+    '''
+    output: '''
       import w from "y";
       export {w};
-    """
+    '''
     errors: [definedError 'x']
     options: [onlyRemoveKnownImports: no]
   ,
-    code: """
+    code: '''
       import w, {y as x} from "y";
       export {w};
-    """
-    output: """
+    '''
+    output: '''
       import w from "y";
       export {w};
-    """
+    '''
     errors: [definedError 'x']
     options: [onlyRemoveKnownImports: no]
   ,
-    code: """
+    code: '''
       import {w, y as x, z} from \"y\";
       export {w, z};
-    """
-    output: """
+    '''
+    output: '''
       import {w, z} from "y";
       export {w, z};
-    """
+    '''
     errors: [definedError 'x']
     options: [onlyRemoveKnownImports: no]
   ,
-    code: """
+    code: '''
       import {y as x, z} from "y";
       export {z};
-    """
-    output: """
+    '''
+    output: '''
       import {z} from "y";
       export {z};
-    """
+    '''
     errors: [definedError 'x']
     options: [onlyRemoveKnownImports: no]
   ,
-    code: """
+    code: '''
       import {y as x, z} from "y";
       export {z};
-    """
-    output: """
+    '''
+    output: '''
       import {z} from "y";
       export {z};
-    """
+    '''
     errors: [definedError 'x']
     options: [onlyRemoveKnownImports: no]
   ,
-    code: """
+    code: '''
       import {w, y as x} from "y";
       export {w};
-    """
-    output: """
+    '''
+    output: '''
       import {w} from "y";
       export {w};
-    """
+    '''
     errors: [definedError 'x']
     options: [onlyRemoveKnownImports: no]
   ,
-    code: """
+    code: '''
       import * as y from "y";
       const w = 3;
       export {w};
-    """
-    output: """
+    '''
+    output: '''
       const w = 3;
       export {w};
-    """
+    '''
     errors: [definedError 'y']
     options: [onlyRemoveKnownImports: no]
   ,
-    code: """
+    code: '''
       import View from "react-native";
       export const a = 1;
-    """
-    output: """
+    '''
+    output: '''
       export const a = 1;
-    """
+    '''
     errors: [definedError 'View']
     options: [onlyRemoveKnownImports: yes]
   ,
-    code: """
+    code: '''
       import x from "y";
       export const a = 1;
-    """
-    output: """
+    '''
+    output: '''
       import x from "y";
       export const a = 1;
-    """
+    '''
     errors: [definedError 'x']
     options: [onlyRemoveKnownImports: yes]
   ,
-    code: """
+    code: '''
       import {map as fmap} from "lodash/fp";
       export const a = 1;
-    """
-    output: """
+    '''
+    output: '''
       export const a = 1;
-    """
+    '''
     errors: [definedError 'fmap']
     options: [onlyRemoveKnownImports: yes]
   ,
     # respect knownImportsFile config
-    code: """
+    code: '''
       import numeral from "numeral";
       export const a = 1;
-    """
-    output: """
+    '''
+    output: '''
       import numeral from "numeral";
       export const a = 1;
-    """
+    '''
     errors: [definedError 'numeral']
     options: [onlyRemoveKnownImports: yes]
     settings:
       'known-imports/config-file-path': 'other-known-imports.json'
   ,
     # respect inline knownImports
-    code: """
+    code: '''
       import numeral from "numeral";
       export const a = 1;
-    """
-    output: """
+    '''
+    output: '''
       export const a = 1;
-    """
+    '''
     errors: [definedError 'numeral']
     options: [onlyRemoveKnownImports: yes]
     settings:
@@ -254,57 +254,57 @@ ruleTester.run 'no-unused-vars', rule,
           default: yes
   ,
     # preserve blank line
-    code: """
+    code: '''
       import b from "b";
       import c from "c";
 
       import someLocalDependency from "../somewhere";
 
       export const a = b + someLocalDependency;
-    """
-    output: """
+    '''
+    output: '''
       import b from "b";
 
       import someLocalDependency from "../somewhere";
 
       export const a = b + someLocalDependency;
-    """
+    '''
     errors: [definedError 'c']
   ,
     # ...but not at the beginning of the file
-    code: """
+    code: '''
       import c from "c";
 
       import someLocalDependency from "../somewhere";
 
       export const a = someLocalDependency;
-    """
-    output: """
+    '''
+    output: '''
       import someLocalDependency from "../somewhere";
 
       export const a = someLocalDependency;
-    """
+    '''
     errors: [definedError 'c']
   ,
     # onlyRemoveKnownImports understands whitelist filename
-    code: """
+    code: '''
       import Empty from "fixtures/Empty";
       export const a = 1;
-    """
-    output: """
+    '''
+    output: '''
       export const a = 1;
-    """
+    '''
     errors: [definedError 'Empty']
     options: [onlyRemoveKnownImports: yes]
   ,
     # onlyRemoveKnownImports understands whitelist named
-    code: """
+    code: '''
       import {one} from "fixtures/named";
       export const a = 1;
-    """
-    output: """
+    '''
+    output: '''
       export const a = 1;
-    """
+    '''
     errors: [definedError 'one']
     options: [onlyRemoveKnownImports: yes]
   ]

--- a/src/utils/index.coffee
+++ b/src/utils/index.coffee
@@ -450,4 +450,77 @@ getAddImportFix = ({name, context, allImports, lastNonlocalImport}) ->
       } from '#{knownImport.module}'"
     )
 
-module.exports = {knownImportExists, getAddImportFix}
+getRemoveImportFix = ({unusedVar, onlyRemoveKnownImports, context}) ->
+  def = unusedVar.defs[0]
+  return null unless def.type is 'ImportBinding'
+  return null if (
+    onlyRemoveKnownImports and
+    not knownImportExists {name: unusedVar.name, context}
+  )
+
+  importDeclaration = def.parent
+  importSpecifier = def.node
+
+  sourceCode = context.getSourceCode()
+
+  (fixer) ->
+    removeEntireImport = ->
+      nextToken = sourceCode.getTokenAfter importDeclaration
+      if (precedingComments = sourceCode.getCommentsBefore nextToken).length
+        nextToken = precedingComments[0]
+      nextTokenIsPrecededByBlankLine =
+        sourceCode.text[(nextToken.range[0] - 2)...nextToken.range[0]] is '\n\n'
+      importIsAtBeginningOfFile = not sourceCode.getTokenBefore(
+        importDeclaration
+      )
+      fixer.removeRange [
+        importDeclaration.range[0]
+        if nextTokenIsPrecededByBlankLine and not importIsAtBeginningOfFile
+          nextToken.range[0] - 1
+        else
+          nextToken.range[0]
+      ]
+
+    removeThroughFollowingComma = ({commaToken}) ->
+      followingToken = sourceCode.getTokenAfter commaToken
+      return fixer.removeRange [
+        importSpecifier.range[0]
+        followingToken.range[0]
+      ]
+
+    removeThroughPrecedingComma = ({commaToken}) ->
+      beforeToken = sourceCode.getTokenBefore commaToken
+      return fixer.removeRange [beforeToken.range[1], importSpecifier.range[1]]
+
+    removeBracesAndPrecedingComma = ->
+      openingBrace = sourceCode.getTokenBefore importSpecifier,
+        filter: ({value}) -> value is '{'
+      closingBrace = sourceCode.getTokenAfter importSpecifier,
+        filter: ({value}) -> value is '}'
+      precedingComma = sourceCode.getTokenBefore openingBrace
+      # assert(precedingComma.value === ',')
+      beforeToken = sourceCode.getTokenBefore precedingComma
+      return fixer.removeRange [beforeToken.range[1], closingBrace.range[1]]
+      # followingComma = sourceCode.getTokenAfter(closingBrace)
+
+    return removeEntireImport() if importDeclaration.specifiers.length is 1
+
+    nextToken = sourceCode.getTokenAfter importSpecifier
+    return removeThroughFollowingComma commaToken: nextToken if (
+      nextToken.value is ','
+    )
+
+    precedingToken = sourceCode.getTokenBefore importSpecifier
+    return removeThroughPrecedingComma commaToken: precedingToken if (
+      precedingToken.value is ','
+    )
+
+    isOnlyNamedImport =
+      importSpecifier.type is 'ImportSpecifier' and
+      importDeclaration.specifiers.filter(({type}) ->
+        type is 'ImportSpecifier'
+      ).length is 1
+    return removeBracesAndPrecedingComma() if isOnlyNamedImport
+    fixer.remove importSpecifier
+
+module.exports = {knownImportExists, getAddImportFix, getRemoveImportFix}

--- a/yarn.lock
+++ b/yarn.lock
@@ -70,15 +70,80 @@
   resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.3.tgz#f060bf6eaafae4d56a7dac618980838b0696e2ab"
   integrity sha512-FmuxfCuolpLl0AnQ2NHSzoUKWEJDFl63qXjzdoWBVyFCXzMGm1spBzk7LeHNoVCiWCF7mRVms9e6jEV9+MoPbg==
 
+"@nodelib/fs.scandir@2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz#d4b3549a5db5de2683e0c1071ab4f140904bbf69"
+  integrity sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==
+  dependencies:
+    "@nodelib/fs.stat" "2.0.4"
+    run-parallel "^1.1.9"
+
+"@nodelib/fs.stat@2.0.4", "@nodelib/fs.stat@^2.0.2":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz#a3f2dd61bab43b8db8fa108a121cfffe4c676655"
+  integrity sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==
+
+"@nodelib/fs.walk@^1.2.3":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz#cce9396b30aa5afe9e3756608f5831adcb53d063"
+  integrity sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==
+  dependencies:
+    "@nodelib/fs.scandir" "2.1.4"
+    fastq "^1.6.0"
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/json-schema@^7.0.3":
+  version "7.0.7"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
+  integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
+
 "@types/unist@^2.0.0", "@types/unist@^2.0.2":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
+
+"@typescript-eslint/eslint-plugin@^4.15.1":
+  version "4.15.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.15.1.tgz#835f64aa0a403e5e9e64c10ceaf8d05c3f015180"
+  integrity sha512-yW2epMYZSpNJXZy22Biu+fLdTG8Mn6b22kR3TqblVk50HGNV8Zya15WAXuQCr8tKw4Qf1BL4QtI6kv6PCkLoJw==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "4.15.1"
+    "@typescript-eslint/scope-manager" "4.15.1"
+    debug "^4.1.1"
+    functional-red-black-tree "^1.0.1"
+    lodash "^4.17.15"
+    regexpp "^3.0.0"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/experimental-utils@4.15.1", "@typescript-eslint/experimental-utils@^4.15.1":
+  version "4.15.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.15.1.tgz#d744d1ac40570a84b447f7aa1b526368afd17eec"
+  integrity sha512-9LQRmOzBRI1iOdJorr4jEnQhadxK4c9R2aEAsm7WE/7dq8wkKD1suaV0S/JucTL8QlYUPU1y2yjqg+aGC0IQBQ==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/scope-manager" "4.15.1"
+    "@typescript-eslint/types" "4.15.1"
+    "@typescript-eslint/typescript-estree" "4.15.1"
+    eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
+
+"@typescript-eslint/scope-manager@4.15.1", "@typescript-eslint/scope-manager@^4.15.1":
+  version "4.15.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.15.1.tgz#f6511eb38def2a8a6be600c530c243bbb56ac135"
+  integrity sha512-ibQrTFcAm7yG4C1iwpIYK7vDnFg+fKaZVfvyOm3sNsGAerKfwPVFtYft5EbjzByDJ4dj1WD8/34REJfw/9wdVA==
+  dependencies:
+    "@typescript-eslint/types" "4.15.1"
+    "@typescript-eslint/visitor-keys" "4.15.1"
+
+"@typescript-eslint/types@4.15.1":
+  version "4.15.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.15.1.tgz#da702f544ef1afae4bc98da699eaecd49cf31c8c"
+  integrity sha512-iGsaUyWFyLz0mHfXhX4zO6P7O3sExQpBJ2dgXB0G5g/8PRVfBBsmQIc3r83ranEQTALLR3Vko/fnCIVqmH+mPw==
 
 "@typescript-eslint/typescript-estree@2.11.0":
   version "2.11.0"
@@ -92,6 +157,27 @@
     lodash.unescape "4.0.1"
     semver "^6.3.0"
     tsutils "^3.17.1"
+
+"@typescript-eslint/typescript-estree@4.15.1":
+  version "4.15.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.15.1.tgz#fa9a9ff88b4a04d901ddbe5b248bc0a00cd610be"
+  integrity sha512-z8MN3CicTEumrWAEB2e2CcoZa3KP9+SMYLIA2aM49XW3cWIaiVSOAGq30ffR5XHxRirqE90fgLw3e6WmNx5uNw==
+  dependencies:
+    "@typescript-eslint/types" "4.15.1"
+    "@typescript-eslint/visitor-keys" "4.15.1"
+    debug "^4.1.1"
+    globby "^11.0.1"
+    is-glob "^4.0.1"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/visitor-keys@4.15.1":
+  version "4.15.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.15.1.tgz#c76abbf2a3be8a70ed760f0e5756bf62de5865dd"
+  integrity sha512-tYzaTP9plooRJY8eNlpAewTOqtWW/4ff/5wBjNVaJ0S0wC4Gpq/zDVRTJa5bq2v1pCNQ08xxMCndcvR+h7lMww==
+  dependencies:
+    "@typescript-eslint/types" "4.15.1"
+    eslint-visitor-keys "^2.0.0"
 
 acorn-jsx@^5.2.0:
   version "5.2.0"
@@ -219,6 +305,11 @@ array-union@^1.0.1:
   dependencies:
     array-uniq "^1.0.1"
 
+array-union@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
+  integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
+
 array-uniq@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
@@ -338,6 +429,13 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+braces@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
+  integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
+  dependencies:
+    fill-range "^7.0.1"
 
 browser-stdout@1.3.1:
   version "1.3.1"
@@ -604,6 +702,13 @@ diff@4.0.1:
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.1.tgz#0c667cb467ebbb5cea7f14f135cc2dba7780a8ff"
   integrity sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==
 
+dir-glob@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
+  integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
+  dependencies:
+    path-type "^4.0.0"
+
 doctrine@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
@@ -766,10 +871,9 @@ eslint-module-utils@^2.4.1:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
 
-eslint-plugin-coffee@^0.1.12:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-coffee/-/eslint-plugin-coffee-0.1.12.tgz#1bb2f41b62fd75b258062cd8dfa230c41eaff2c1"
-  integrity sha512-ThsCQLHhuxpQrqV7mH5+Xlf6Zt3rrzAgkvoduhdzoIwa8xRLxXUahAW1R3FGT/ci04f+8Z9kqlz52/9QtVWxtw==
+"eslint-plugin-coffee@github:helixbass/eslint-plugin-coffee#eslint-plugin-coffee-v0.1.15-dev.1-gitpkg":
+  version "0.1.15-dev.1"
+  resolved "https://codeload.github.com/helixbass/eslint-plugin-coffee/tar.gz/60b12d1e84ad3a5153e1fb93b6d4926a91bd0043"
   dependencies:
     axe-core "^3.4.1"
     babel-eslint "^7.2.2"
@@ -914,6 +1018,13 @@ eslint-utils@^1.4.3:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
+eslint-utils@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
+  integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
+
 eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
@@ -923,6 +1034,11 @@ eslint-visitor-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
   integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
+
+eslint-visitor-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
+  integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
 eslint@^6.0.0:
   version "6.8.0"
@@ -1034,6 +1150,18 @@ fast-diff@^1.1.1:
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
+fast-glob@^3.1.1:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.5.tgz#7939af2a656de79a4f1901903ee8adcaa7cb9661"
+  integrity sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.0"
+    merge2 "^1.3.0"
+    micromatch "^4.0.2"
+    picomatch "^2.2.1"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
@@ -1043,6 +1171,13 @@ fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fastq@^1.6.0:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.10.1.tgz#8b8f2ac8bf3632d67afcd65dac248d5fdc45385e"
+  integrity sha512-AWuv6Ery3pM+dY7LYS8YIaCiQvUaos9OB1RyNgaOWnaX+Tik7Onvcsf8x8c+YtDeT0maYLniBip2hox5KtEXXA==
+  dependencies:
+    reusify "^1.0.4"
 
 figures@^3.0.0:
   version "3.2.0"
@@ -1057,6 +1192,13 @@ file-entry-cache@^5.0.1:
   integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
   dependencies:
     flat-cache "^2.0.1"
+
+fill-range@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
+  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+  dependencies:
+    to-regex-range "^5.0.1"
 
 find-parent-dir@0.3.0:
   version "0.3.0"
@@ -1134,7 +1276,7 @@ get-stream@4.1.0:
   dependencies:
     pump "^3.0.0"
 
-glob-parent@^5.0.0:
+glob-parent@^5.0.0, glob-parent@^5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
   integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
@@ -1199,6 +1341,18 @@ globby@6.1.0:
     object-assign "^4.0.1"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
+
+globby@^11.0.1:
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.2.tgz#1af538b766a3b540ebfb58a32b2e2d5897321d83"
+  integrity sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
+    slash "^3.0.0"
 
 graceful-fs@^4.1.2:
   version "4.2.0"
@@ -1304,6 +1458,11 @@ ignore@4.0.6, ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+ignore@^5.1.4:
+  version "5.1.8"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
+  integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
 import-fresh@^2.0.0:
   version "2.0.0"
@@ -1460,6 +1619,11 @@ is-hexadecimal@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz#e8a426a69b6d31470d3a33a47bb825cda02506ee"
   integrity sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA==
+
+is-number@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
+  integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
 is-plain-obj@^2.0.0:
   version "2.1.0"
@@ -1683,6 +1847,13 @@ lru-cache@^4.1.5:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
+
 map-age-cleaner@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
@@ -1703,6 +1874,19 @@ mem@5.1.1:
     map-age-cleaner "^0.1.3"
     mimic-fn "^2.1.0"
     p-is-promise "^2.1.0"
+
+merge2@^1.3.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
+  integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
+micromatch@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
+  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
+  dependencies:
+    braces "^3.0.1"
+    picomatch "^2.0.5"
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -2039,7 +2223,12 @@ path-type@^2.0.0:
   dependencies:
     pify "^2.0.0"
 
-picomatch@^2.2.2:
+path-type@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
+  integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
+picomatch@^2.0.5, picomatch@^2.2.1, picomatch@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
@@ -2240,6 +2429,11 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
+queue-microtask@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.2.tgz#abf64491e6ecf0f38a6502403d4cda04f372dfd3"
+  integrity sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg==
+
 react-is@^16.8.1:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
@@ -2291,6 +2485,11 @@ regexpp@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
   integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
+
+regexpp@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
+  integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
 
 remark-math@1.0.6:
   version "1.0.6"
@@ -2369,6 +2568,11 @@ restore-cursor@^3.1.0:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
 
+reusify@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
+  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
 rimraf@2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
@@ -2382,6 +2586,13 @@ run-async@^2.4.0:
   integrity sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==
   dependencies:
     is-promise "^2.1.0"
+
+run-parallel@^1.1.9:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
+  integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
+  dependencies:
+    queue-microtask "^1.2.2"
 
 rxjs@^6.5.3:
   version "6.5.5"
@@ -2404,6 +2615,13 @@ semver@6.3.0, semver@^6.1.2, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.3.2:
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
+  integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+  dependencies:
+    lru-cache "^6.0.0"
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -2439,6 +2657,11 @@ simple-html-tokenizer@^0.5.7:
   version "0.5.9"
   resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.5.9.tgz#1a83fe97f5a3e39b335fddf71cfe9b0263b581c2"
   integrity sha512-w/3FEDN94r4JQ9WoYrIr8RqDIPZdyNkdpbK9glFady1CAEyD97XWCv8HFetQO21w81e7h7Nh59iYTyG1mUJftg==
+
+slash@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
+  integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
 slice-ansi@^2.1.0:
   version "2.1.0"
@@ -2671,6 +2894,13 @@ to-fast-properties@^1.0.3:
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
   integrity sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=
 
+to-regex-range@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
+  integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
+  dependencies:
+    is-number "^7.0.0"
+
 trim-trailing-lines@^1.0.0, trim-trailing-lines@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.2.tgz#d2f1e153161152e9f02fabc670fb40bec2ea2e3a"
@@ -2901,6 +3131,11 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml-unist-parser@1.1.1:
   version "1.1.1"


### PR DESCRIPTION
In this PR:
- pull in post-https://github.com/typescript-eslint/typescript-eslint/pull/2039 version of `@typescript-eslint/no-unused-vars` rule (as well as corresponding `@typescript-eslint` dependencies) as starting point for `no-unused-vars` rule in order to be compatible with projects using newer versions of typescript-eslint