### PR TITLE
Only generate whitelisted default import if it exists

### DIFF
--- a/src/tests/fixtures/namedLikeFilename.coffee
+++ b/src/tests/fixtures/namedLikeFilename.coffee
@@ -1,0 +1,1 @@
+export namedLikeFilename = -> 1

--- a/src/tests/rules/no-undef.coffee
+++ b/src/tests/rules/no-undef.coffee
@@ -583,7 +583,7 @@ ruleTester.run 'no-undef', rule,
     ]
     filename: 'lib/foo.js'
   ,
-    # ignore option: filename import + leading-slash directory glob + non-nested import
+    # same-name named vs filename
     code: '''
       namedLikeFilename()
     '''

--- a/src/tests/rules/no-undef.coffee
+++ b/src/tests/rules/no-undef.coffee
@@ -582,4 +582,19 @@ ruleTester.run 'no-undef', rule,
       type: 'Identifier'
     ]
     filename: 'lib/foo.js'
+  ,
+    # ignore option: filename import + leading-slash directory glob + non-nested import
+    code: '''
+      namedLikeFilename()
+    '''
+    output: '''
+      import {namedLikeFilename} from 'fixtures/namedLikeFilename'
+
+      namedLikeFilename()
+    '''
+    errors: [
+      message: "'namedLikeFilename' is not defined."
+      type: 'Identifier'
+    ]
+    filename: 'lib/foo.js'
   ]


### PR DESCRIPTION
Fixes #37 

In this PR:
- check for existence of default export when generating whitelisted default import