### PR TITLE
Support index files in whitelisting

### DIFF
--- a/src/tests/fixtures/subdir/index.coffee
+++ b/src/tests/fixtures/subdir/index.coffee
@@ -1,0 +1,3 @@
+export fromIndex = -> 1
+
+export default 2

--- a/src/tests/rules/no-undef.coffee
+++ b/src/tests/rules/no-undef.coffee
@@ -597,4 +597,34 @@ ruleTester.run 'no-undef', rule,
       type: 'Identifier'
     ]
     filename: 'lib/foo.js'
+  ,
+    # index.js named
+    code: '''
+      fromIndex()
+    '''
+    output: '''
+      import {fromIndex} from 'fixtures/subdir'
+
+      fromIndex()
+    '''
+    errors: [
+      message: "'fromIndex' is not defined."
+      type: 'Identifier'
+    ]
+    filename: 'lib/foo.js'
+  ,
+    # index.js default
+    code: '''
+      subdir()
+    '''
+    output: '''
+      import subdir from 'fixtures/subdir'
+
+      subdir()
+    '''
+    errors: [
+      message: "'subdir' is not defined."
+      type: 'Identifier'
+    ]
+    filename: 'lib/foo.js'
   ]


### PR DESCRIPTION
Fixes #15 

In this PR:
- handle eg `index.js` files as expected for whitelisting