### PR TITLE
Disable typescript no-unused-vars rule

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -30,5 +30,6 @@ module.exports =
         'no-undef': 'off'
         'known-imports/no-undef': 'error'
         'no-unused-vars': 'off'
+        '@typescript-eslint/no-unused-vars': 'off'
         'known-imports/no-unused-vars': 'error'
         'known-imports/no-undef-types': 'error'


### PR DESCRIPTION
In this PR:
- disable `@typescript-eslint/no-unused-vars` rule when using `recommended-typescript` setting